### PR TITLE
Fixes types to avoid explicit casting.

### DIFF
--- a/malis.pyx
+++ b/malis.pyx
@@ -15,10 +15,10 @@ cdef extern from "malis_cpp.h":
                    const int nEdge, const int* node1, const int* node2, const float* edgeWeight,
                    int* seg);
 
-def malis_loss_weights(np.ndarray[np.int32_t,ndim=1] segTrue,
-                np.ndarray[np.int32_t,ndim=1] node1,
-                np.ndarray[np.int32_t,ndim=1] node2,
-                np.ndarray[np.float32_t,ndim=1] edgeWeight,
+def malis_loss_weights(np.ndarray[int, ndim=1] segTrue,
+                np.ndarray[int, ndim=1] node1,
+                np.ndarray[int, ndim=1] node2,
+                np.ndarray[float, ndim=1] edgeWeight,
                 np.int pos):
     cdef int nVert = segTrue.shape[0]
     cdef int nEdge = node1.shape[0]
@@ -26,11 +26,11 @@ def malis_loss_weights(np.ndarray[np.int32_t,ndim=1] segTrue,
     node1 = np.ascontiguousarray(node1)
     node2 = np.ascontiguousarray(node2)
     edgeWeight = np.ascontiguousarray(edgeWeight)
-    cdef np.ndarray[np.int32_t,ndim=1] nPairPerEdge = np.zeros(edgeWeight.shape[0],dtype=np.int32)
-    malis_loss_weights_cpp(nVert, <int*> &segTrue[0],
-                   nEdge, <int*> &node1[0], <int*> &node2[0], <float*> &edgeWeight[0],
+    cdef np.ndarray[int, ndim=1] nPairPerEdge = np.zeros(edgeWeight.shape[0],dtype=np.int32)
+    malis_loss_weights_cpp(nVert, &segTrue[0],
+                   nEdge, &node1[0], &node2[0], &edgeWeight[0],
                    pos,
-                   <int*> &nPairPerEdge[0]);
+                   &nPairPerEdge[0]);
     return nPairPerEdge
 
 def connected_components(np.int nVert,


### PR DESCRIPTION
I think this will fix it for you. Turns out that I was wrong. Cython uses ctypes explicitly so `float` is a single precision float and similarly with all other types.

FWIW, I built and passed some dummy data to it and it gave an answer.

I didn't apply this everywhere, but I think this same strategy can easily be extended.

> The Python types int, long, and float are not available for static typing and instead interpreted as C int, long, and float respectively...

( http://docs.cython.org/src/userguide/language_basics.html#types )
